### PR TITLE
Partial URL update after BFS API migration

### DIFF
--- a/R/i14y_get_codelist.R
+++ b/R/i14y_get_codelist.R
@@ -27,7 +27,7 @@ i14y_get_codelist <- function(
     return(NULL)
   }
 
-  req <- httr2::request("https://api.i14y.admin.ch")
+  req <- httr2::request("https://api.i14y.admin.ch/")
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"

--- a/R/i14y_get_concept.R
+++ b/R/i14y_get_concept.R
@@ -25,7 +25,7 @@ i14y_get_concept <- function(
     return(NULL)
   }
 
-  req <- httr2::request("https://i14y.admin.ch")
+  req <- httr2::request("https://input-backend.i14y.c.bfs.admin.ch")
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"

--- a/R/i14y_get_concept_all_versions.R
+++ b/R/i14y_get_concept_all_versions.R
@@ -25,7 +25,7 @@ i14y_get_concept_all_versions <- function(
     return(NULL)
   }
 
-  req <- httr2::request("https://www.i14y.admin.ch")
+  req <- httr2::request("https://input-backend.i14y.c.bfs.admin.ch")
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"

--- a/R/i14y_get_content_information.R
+++ b/R/i14y_get_content_information.R
@@ -9,23 +9,23 @@
 #' )
 #' @export
 i14y_get_content_information <- function(
-  identifier = NULL
+    id = NULL
 ) {
-  check_not_null(identifier)
-  check_string(identifier)
+  check_not_null(id)
+  check_string(id)
   if (!curl::has_internet()) {
     message("No internet connection")
     return(NULL)
   }
 
-  req <- httr2::request("https://www.i14y.admin.ch")
+  req <- httr2::request("https://input-backend.i14y.c.bfs.admin.ch/")
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"
   )
   req <- httr2::req_url_path_append(
     req,
-    paste0("/api/ContentConfigurations/", identifier)
+    paste0("/api/Dataset/", identifier)
   )
   req <- httr2::req_retry(req, max_tries = 2)
   req <- httr2::req_perform(req)

--- a/R/i14y_get_dataset_metadata.R
+++ b/R/i14y_get_dataset_metadata.R
@@ -17,7 +17,7 @@ i14y_get_dataset_metadata <- function(
     return(NULL)
   }
 
-  req <- httr2::request(paste0("https://input.i14y.admin.ch/api/Dataset/", id))
+  req <- httr2::request(paste0("https://input-backend.i14y.c.bfs.admin.ch/api/Dataset/", id))
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"

--- a/R/i14y_search_catalog.R
+++ b/R/i14y_search_catalog.R
@@ -42,7 +42,7 @@ i14y_search_catalog <- function(
     return(NULL)
   }
 
-  req <- httr2::request("https://input.i14y.admin.ch/api/Catalog/search")
+  req <- httr2::request("https://input-backend.i14y.c.bfs.admin.ch/api/Catalog/search")
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"

--- a/R/i14y_search_concept.R
+++ b/R/i14y_search_concept.R
@@ -59,7 +59,7 @@ i14y_search_concept <- function(
     )
   }
 
-  req <- httr2::request("https://input.i14y.admin.ch/api/Catalog/search")
+  req <- httr2::request("https://input-backend.i14y.c.bfs.admin.ch/api/Catalog/search")
   req <- httr2::req_user_agent(
     req,
     "I14Y R package (https://github.com/lgnbhl/I14Y)"

--- a/man/i14y_get_content_information.Rd
+++ b/man/i14y_get_content_information.Rd
@@ -4,7 +4,7 @@
 \alias{i14y_get_content_information}
 \title{Get the information of a nomenclature by identifier}
 \usage{
-i14y_get_content_information(identifier = NULL)
+i14y_get_content_information(id = NULL)
 }
 \arguments{
 \item{identifier}{string. The identifier of the nomenclature.}


### PR DESCRIPTION
Hello Félix,

After the BFS migrated the I14Y platform, several functions returned 404 errors. I updated the URLs where I could identify the new endpoints. Some functions I wasn't able to fix — the endpoints they relied on don't seem to exist in the Swagger console anymore, though I'm not 100% sure about this.

**Fixed — URL updated**

i14y_get_codelist()
i14y_get_concept_all_versions()
i14y_get_concept()
i14y_get_dataset_metadata()
i14y_search_catalog()
i14y_search_concept()

**Not fixed — unclear status**

These functions still return errors. The endpoints they use don't appear to be in the Swagger console anymore, but I'm not entirely sure if they've been moved, renamed or dropped:

i14y_get_content_information()
i14y_get_nomenclature_level_multiple()
i14y_get_nomenclature_level()
i14y_search_nomenclature()
i14y_get_data_structure()

Please notice that for example the element SpiGes_Erhebung_Administratives no longer seems to be in the catalog. That is why some of the tests fail.

Best Regards
Felix